### PR TITLE
Utilisation du mode passif pour ftp

### DIFF
--- a/static.php
+++ b/static.php
@@ -798,6 +798,7 @@ else {
 	if ($timestampNow - $stop < 1200) {
 		$conn_id = ftp_connect($ftp_server) or die("could not connect to $ftp_server");
 		if (!@ftp_login($conn_id, $ftp_username, $ftp_password)) { die("could not connect to infoclimat");}
+		ftp_pasv($conn_id, true);
 		$remote="StatIC_".$id_station.".txt";
 		ftp_put($conn_id, $remote, $file, FTP_ASCII);
 		ftp_close($conn_id);


### PR DESCRIPTION
Derrière un firewall, il est nécessaire d'être en mode passif, sinon le fichier ne peut êter envoyé (timeout sinon).